### PR TITLE
Update limiter_cut_character_sheet.csv

### DIFF
--- a/limiter_cut_character_sheet.csv
+++ b/limiter_cut_character_sheet.csv
@@ -5,4 +5,4 @@
 ヨルスケ・ヨーライハ,300,https://character-sheets.appspot.com/dx3/edit.html?key=ahVzfmNoYXJhY3Rlci1zaGVldHMtbXByFwsSDUNoYXJhY3RlckRhdGEYmJHBvwMM
 ベン・ベックマン, 300, http://character-sheets.appspot.com/dx3/edit.html?key=ahVzfmNoYXJhY3Rlci1zaGVldHMtbXByFwsSDUNoYXJhY3RlckRhdGEYnaaduQMM
 鹿目　まどか(Dロイスあり), 230, https://character-sheets.appspot.com/dx3/edit.html?key=ahVzfmNoYXJhY3Rlci1zaGVldHMtbXByFwsSDUNoYXJhY3RlckRhdGEYsrq1tAMM
-サプハラ赤城さん, ,https://character-sheets.appspot.com/dx3/edit.html?key=ahVzfmNoYXJhY3Rlci1zaGVldHMtbXByFwsSDUNoYXJhY3RlckRhdGEYnvyNvAMM
+サプハラ赤城さん,230 ,https://character-sheets.appspot.com/dx3/edit.html?key=ahVzfmNoYXJhY3Rlci1zaGVldHMtbXByFwsSDUNoYXJhY3RlckRhdGEYnvyNvAMM


### PR DESCRIPTION
経験点が空欄だったので加えておいたことを教える
基本的には130+取得EXP-残/不足EXPがそのキャラの経験点であることも教える