### PR TITLE
ログページ生成におけるubuntu20.04EOLに対応

### DIFF
--- a/.github/workflows/generateLogPage.yml
+++ b/.github/workflows/generateLogPage.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository == 'orga-itsuka-trpg/TRPG-OCL-Rule'
     
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
GitHub Actionによるログの自動生成において、action時に使用していたubuntuのバージョンがEOLして…死んだ！
手元のブランチでは動作したので、こちらもひとまず24.04で様子を見る…だろ？